### PR TITLE
feat: pre-render inline images to SD raw4 cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         
-      - name: Setup PlatformIO
-        uses: arduino/setup-platformio@v1
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          version: latest
+          python-version: '3.11'
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Prepare config header for CI build
+        run: cp include/config.h.example include/config.h
           
       - name: Build
         run: pio run

--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ After a successful SD mount, the firmware now ensures the app folders below exis
 │   ├── .progress/
 │   │   └── <book>.json
 │   └── .linecache/
-│       └── ch<chapter>.txt
+│       ├── ch<chapter>.txt
+│       └── inline/
+│           ├── img_<hash>.<png|jpg|jpeg>
+│           └── raw4_<hash>_<w>x<h>.r4
 └── sleep/
     ├── *.png
     └── *.jpg
@@ -88,6 +91,7 @@ Notes:
 - `/books` is the main library folder.
 - `/books/.progress` stores reading position and last-read order.
 - `/books/.linecache` stores wrapped chapter text on SD to reduce RAM pressure.
+- `/books/.linecache/inline` stores extracted EPUB images and pre-rendered 4-bit grayscale image caches so reader page draw can stream from SD instead of decoding PNG/JPEG live.
 - `/sleep` is optional from a user perspective, but the firmware auto-creates it when the SD card mounts successfully.
 - If there are no valid images in `/sleep`, the device still sleeps normally and shows the built-in fallback screen.
 

--- a/src/epub.cpp
+++ b/src/epub.cpp
@@ -119,22 +119,25 @@ bool ZipReader::fileExists(const char* name) {
     return false;
 }
 
+static bool zipSeekToData(FILE* f, const ZipEntry& entry) {
+    fseek(f, entry.local_header_offset, SEEK_SET);
+    uint8_t lfh[30];
+    if (fread(lfh, 1, 30, f) != 30) return false;
+    if (read32(lfh) != 0x04034b50) return false;
+
+    uint16_t nameLen  = read16(lfh + 26);
+    uint16_t extraLen = read16(lfh + 28);
+    long dataOffset = entry.local_header_offset + 30 + nameLen + extraLen;
+    return fseek(f, dataOffset, SEEK_SET) == 0;
+}
+
 uint8_t* ZipReader::readFile(const char* name, size_t* outSize) {
     *outSize = 0;
 
     for (const auto& entry : _entries) {
         if (entry.name != name) continue;
 
-        // Read local file header to find data offset
-        fseek(_f, entry.local_header_offset, SEEK_SET);
-        uint8_t lfh[30];
-        if (fread(lfh, 1, 30, _f) != 30) return nullptr;
-        if (read32(lfh) != 0x04034b50) return nullptr;
-
-        uint16_t nameLen  = read16(lfh + 26);
-        uint16_t extraLen = read16(lfh + 28);
-        long dataOffset = entry.local_header_offset + 30 + nameLen + extraLen;
-        fseek(_f, dataOffset, SEEK_SET);
+        if (!zipSeekToData(_f, entry)) return nullptr;
 
         if (entry.compression_method == 0) {
             // STORED — just read directly
@@ -180,6 +183,71 @@ uint8_t* ZipReader::readFile(const char* name, size_t* outSize) {
         break;
     }
     return nullptr;
+}
+
+bool ZipReader::extractFileTo(const char* name, const char* outPath, size_t* outSize) {
+    if (outSize) *outSize = 0;
+    if (!_f || !name || !outPath) return false;
+
+    for (const auto& entry : _entries) {
+        if (entry.name != name) continue;
+        if (!zipSeekToData(_f, entry)) return false;
+
+        FILE* out = fopen(outPath, "wb");
+        if (!out) return false;
+
+        bool ok = false;
+        if (entry.compression_method == 0) {
+            uint8_t buf[1024];
+            uint32_t remaining = entry.uncompressed_size;
+            ok = true;
+            while (remaining > 0) {
+                size_t want = remaining > sizeof(buf) ? sizeof(buf) : remaining;
+                size_t n = fread(buf, 1, want, _f);
+                if (n != want || fwrite(buf, 1, n, out) != n) { ok = false; break; }
+                remaining -= n;
+                yield();
+            }
+        } else if (entry.compression_method == 8) {
+            uint8_t inBuf[1024];
+            uint8_t outBuf[1024];
+            z_stream strm;
+            memset(&strm, 0, sizeof(strm));
+            ok = inflateInit2(&strm, -MAX_WBITS) == Z_OK;
+            uint32_t compressedRemaining = entry.compressed_size;
+
+            while (ok) {
+                if (strm.avail_in == 0 && compressedRemaining > 0) {
+                    size_t want = compressedRemaining > sizeof(inBuf) ? sizeof(inBuf) : compressedRemaining;
+                    size_t n = fread(inBuf, 1, want, _f);
+                    if (n != want) { ok = false; break; }
+                    compressedRemaining -= n;
+                    strm.next_in = inBuf;
+                    strm.avail_in = n;
+                }
+
+                strm.next_out = outBuf;
+                strm.avail_out = sizeof(outBuf);
+                int ret = inflate(&strm, compressedRemaining == 0 ? Z_FINISH : Z_NO_FLUSH);
+                size_t produced = sizeof(outBuf) - strm.avail_out;
+                if (produced && fwrite(outBuf, 1, produced, out) != produced) { ok = false; break; }
+                if (ret == Z_STREAM_END) break;
+                if (ret != Z_OK) { ok = false; break; }
+                yield();
+            }
+            inflateEnd(&strm);
+        }
+
+        long finalSize = ftell(out);
+        fclose(out);
+        if (!ok || finalSize < 0 || (uint32_t)finalSize != entry.uncompressed_size) {
+            remove(outPath);
+            return false;
+        }
+        if (outSize) *outSize = (size_t)finalSize;
+        return true;
+    }
+    return false;
 }
 
 
@@ -709,6 +777,10 @@ String EpubParser::getChapterHtml(int index) {
 
 uint8_t* EpubParser::readAsset(const String& zipPath, size_t* outSize) {
     return _zip.readFile(zipPath.c_str(), outSize);
+}
+
+bool EpubParser::extractAssetToFile(const String& zipPath, const String& outPath, size_t* outSize) {
+    return _zip.extractFileTo(zipPath.c_str(), outPath.c_str(), outSize);
 }
 
 String EpubParser::resolveChapterAssetPath(int chapterIndex, const String& relativePath) {

--- a/src/epub.h
+++ b/src/epub.h
@@ -17,6 +17,7 @@ public:
     bool open(const char* path);
     void close();
     uint8_t* readFile(const char* name, size_t* out_size);
+    bool extractFileTo(const char* name, const char* outPath, size_t* out_size);
     bool fileExists(const char* name);
 
 private:
@@ -63,6 +64,7 @@ public:
     String getCoverImagePath() const { return _coverImagePath; }
     bool hasCoverImage() const { return _coverImagePath.length() > 0; }
     uint8_t* readAsset(const String& zipPath, size_t* outSize);
+    bool extractAssetToFile(const String& zipPath, const String& outPath, size_t* outSize);
     String resolveChapterAssetPath(int chapterIndex, const String& relativePath);
 
     // Chapter title cache access for progress JSON persistence

--- a/src/inline_image.cpp
+++ b/src/inline_image.cpp
@@ -10,61 +10,66 @@
 #include <algorithm>
 #include <cstdio>
 
-struct ImgDrawCtx {
+struct Raw4Ctx {
     int srcW = 0, srcH = 0;
-    int dstX = 0, dstY = 0;
     int dstW = 0, dstH = 0;
+    File* out = nullptr;
+    uint8_t* row = nullptr;
+    uint8_t* hits = nullptr;
     uint16_t* pngLineBuf = nullptr;
     uint32_t deadlineMs = 0;
     uint32_t lastYieldMs = 0;
     bool aborted = false;
 };
 
-static ImgDrawCtx* g_ictx = nullptr;
-static PNG* g_ipng_active = nullptr;
+static Raw4Ctx* g_raw4_ctx = nullptr;
+static PNG* g_png_active = nullptr;
 
 static bool inline_image_maybe_abort_decode() {
-    if (!g_ictx) return false;
+    if (!g_raw4_ctx) return false;
     uint32_t now = millis();
-    if (g_ictx->deadlineMs && (int32_t)(now - g_ictx->deadlineMs) >= 0) {
-        g_ictx->aborted = true;
+    if (g_raw4_ctx->deadlineMs && (int32_t)(now - g_raw4_ctx->deadlineMs) >= 0) {
+        g_raw4_ctx->aborted = true;
         return true;
     }
-    if (now - g_ictx->lastYieldMs >= 16) {
+    if (now - g_raw4_ctx->lastYieldMs >= 16) {
         yield();
-        g_ictx->lastYieldMs = now;
+        g_raw4_ctx->lastYieldMs = now;
     }
     return false;
 }
 
-static inline void plot_scaled(int sx, int sy, uint8_t gray4) {
-    if (!g_ictx || g_ictx->srcW <= 0 || g_ictx->srcH <= 0) return;
-    int dx = g_ictx->dstX + (sx * g_ictx->dstW) / g_ictx->srcW;
-    int dy = g_ictx->dstY + (sy * g_ictx->dstH) / g_ictx->srcH;
-    if (dx < 0 || dy < 0 || dx >= display_width() || dy >= display_height()) return;
-    display_draw_pixel(dx, dy, gray4);
+static void raw4_accumulate(int sx, int sy, uint8_t gray4) {
+    Raw4Ctx* ctx = g_raw4_ctx;
+    if (!ctx || !ctx->row || !ctx->hits || ctx->srcW <= 0 || ctx->srcH <= 0) return;
+    int dx = (sx * ctx->dstW) / ctx->srcW;
+    int dy = (sy * ctx->dstH) / ctx->srcH;
+    if (dx < 0 || dy < 0 || dx >= ctx->dstW || dy < 0 || dy >= ctx->dstH) return;
+    size_t idx = (size_t)dy * ctx->dstW + dx;
+    ctx->row[idx] = gray4 & 0x0F;
+    ctx->hits[idx] = 1;
 }
 
-static int ijpegDraw(JPEGDRAW* pDraw) {
-    if (!g_ictx || !pDraw) return 0;
+static int raw4JpegDraw(JPEGDRAW* pDraw) {
+    if (!g_raw4_ctx || !pDraw) return 0;
     for (int yy = 0; yy < pDraw->iHeight; yy++) {
         if (inline_image_maybe_abort_decode()) return 0;
         for (int xx = 0; xx < pDraw->iWidth; xx++) {
             uint16_t px = pDraw->pPixels[yy * pDraw->iWidth + xx];
-            plot_scaled(pDraw->x + xx, pDraw->y + yy, image_rgb565_to_gray4(px));
+            raw4_accumulate(pDraw->x + xx, pDraw->y + yy, image_rgb565_to_gray4(px));
         }
     }
     return 1;
 }
 
-static int ipngDraw(PNGDRAW* pDraw) {
-    if (!g_ictx || !pDraw || !g_ictx->pngLineBuf || !g_ipng_active) return 0;
+static int raw4PngDraw(PNGDRAW* pDraw) {
+    if (!g_raw4_ctx || !pDraw || !g_raw4_ctx->pngLineBuf || !g_png_active) return 0;
     if (inline_image_maybe_abort_decode()) return 0;
-    if (pDraw->iWidth <= 0 || pDraw->iWidth > 1024) return 0;
+    if (pDraw->iWidth <= 0 || pDraw->iWidth > g_raw4_ctx->srcW) return 0;
 
-    g_ipng_active->getLineAsRGB565(pDraw, g_ictx->pngLineBuf, PNG_RGB565_LITTLE_ENDIAN, 0xffffffff);
+    g_png_active->getLineAsRGB565(pDraw, g_raw4_ctx->pngLineBuf, PNG_RGB565_LITTLE_ENDIAN, 0xffffffff);
     for (int xx = 0; xx < pDraw->iWidth; xx++) {
-        plot_scaled(xx, pDraw->y, image_rgb565_to_gray4(g_ictx->pngLineBuf[xx]));
+        raw4_accumulate(xx, pDraw->y, image_rgb565_to_gray4(g_raw4_ctx->pngLineBuf[xx]));
     }
     return 1;
 }
@@ -117,12 +122,16 @@ static void* pngFileOpen(const char* path, int32_t* outSize) {
 
 static int32_t pngFileRead(PNGFILE* pFile, uint8_t* pBuf, int32_t len) {
     if (!pFile || !pFile->fHandle) return 0;
-    return (int32_t)((File*)pFile->fHandle)->read(pBuf, len);
+    int32_t n = (int32_t)((File*)pFile->fHandle)->read(pBuf, len);
+    if (n > 0) pFile->iPos += n;
+    return n > 0 ? n : 0;
 }
 
 static int32_t pngFileSeek(PNGFILE* pFile, int32_t position) {
-    if (!pFile || !pFile->fHandle) return 0;
-    return ((File*)pFile->fHandle)->seek(position) ? position : 0;
+    if (!pFile || !pFile->fHandle) return -1;
+    if (!((File*)pFile->fHandle)->seek(position)) return -1;
+    pFile->iPos = position;
+    return position;
 }
 
 static void pngFileClose(void* handle) {
@@ -354,6 +363,103 @@ static bool probe_image_file(const String& assetPath, int& imgW, int& imgH, size
     return ok;
 }
 
+static String raw4_cache_path_for(const String& assetPath, int w, int h) {
+    uint32_t hval = fnv1a_hash(assetPath, String(w) + "x" + String(h));
+    return inline_cache_dir() + "/raw4_" + String(hval, HEX) + "_" + String(w) + "x" + String(h) + ".r4";
+}
+
+static bool raw4_has_valid_size(const String& path, int w, int h) {
+    size_t sz = 0;
+    if (!file_has_content(path, &sz)) return false;
+    return sz == (size_t)w * (size_t)h;
+}
+
+static bool write_raw4_cache_from_image(const String& assetPath, const String& rawPath,
+                                        int srcW, int srcH, int dstW, int dstH,
+                                        size_t assetSize) {
+    if (!isSupportedImage(assetPath) || dstW <= 0 || dstH <= 0) return false;
+    if (!inline_image_asset_ok(assetSize, srcW, srcH, isPng(assetPath))) return false;
+    if ((uint64_t)dstW * (uint64_t)dstH > 540ULL * 960ULL) return false;
+    if (!ensure_inline_cache_dir()) return false;
+
+    String tmpPath = rawPath + ".tmp";
+    SD.remove(tmpPath);
+    File out = SD.open(tmpPath, FILE_WRITE);
+    if (!out) return false;
+
+    Raw4Ctx ctx;
+    ctx.srcW = srcW;
+    ctx.srcH = srcH;
+    ctx.dstW = dstW;
+    ctx.dstH = dstH;
+    ctx.out = &out;
+    ctx.deadlineMs = millis() + 2500;
+    ctx.lastYieldMs = millis();
+
+    size_t pixelCount = (size_t)dstW * (size_t)dstH;
+    ctx.row = (uint8_t*)ps_malloc(pixelCount);
+    ctx.hits = (uint8_t*)ps_calloc(pixelCount, 1);
+    if (!ctx.row || !ctx.hits) {
+        if (ctx.row) free(ctx.row);
+        if (ctx.hits) free(ctx.hits);
+        out.close();
+        SD.remove(tmpPath);
+        return false;
+    }
+    memset(ctx.row, 15, pixelCount);
+
+    bool ok = false;
+    if (isJpeg(assetPath)) {
+        debug_trace_mark("inline_image_raw4:jpeg", assetPath);
+        JPEGDEC* jpeg = new JPEGDEC();
+        if (jpeg && jpeg->open(assetPath.c_str(), jpegFileOpen, jpegFileClose, jpegFileRead, jpegFileSeek, raw4JpegDraw)) {
+            g_raw4_ctx = &ctx;
+            ok = jpeg->decode(0, 0, 0) == 1 && !ctx.aborted;
+            g_raw4_ctx = nullptr;
+            jpeg->close();
+        }
+        delete jpeg;
+    } else if (isPng(assetPath)) {
+        debug_trace_mark("inline_image_raw4:png", assetPath);
+        PNG* png = new PNG();
+        if (png && png->open(assetPath.c_str(), pngFileOpen, pngFileClose, pngFileRead, pngFileSeek, raw4PngDraw) == PNG_SUCCESS) {
+            ctx.pngLineBuf = (uint16_t*)ps_malloc((size_t)srcW * sizeof(uint16_t));
+            if (ctx.pngLineBuf) {
+                g_raw4_ctx = &ctx;
+                g_png_active = png;
+                ok = png->decode(nullptr, 0) == PNG_SUCCESS && !ctx.aborted;
+                g_png_active = nullptr;
+                g_raw4_ctx = nullptr;
+                free(ctx.pngLineBuf);
+                ctx.pngLineBuf = nullptr;
+            }
+            png->close();
+        }
+        delete png;
+    }
+
+    if (ok) {
+        size_t written = out.write(ctx.row, pixelCount);
+        ok = (written == pixelCount);
+    }
+
+    free(ctx.row);
+    free(ctx.hits);
+    out.close();
+
+    if (!ok) {
+        SD.remove(tmpPath);
+        return false;
+    }
+
+    SD.remove(rawPath);
+    if (!SD.rename(tmpPath, rawPath)) {
+        SD.remove(tmpPath);
+        return false;
+    }
+    return raw4_has_valid_size(rawPath, dstW, dstH);
+}
+
 bool inline_image_probe(EpubParser& parser, const String& bookPath, const String& zipPath,
                         int maxW, int maxH, InlineImageInfo& out) {
     debug_trace_mark("inline_image_probe:start", zipPath);
@@ -370,68 +476,68 @@ bool inline_image_probe(EpubParser& parser, const String& bookPath, const String
     if (!inline_image_asset_ok(assetSize, imgW, imgH, isPng(assetPath))) return false;
     if (imgW < 10 && imgH < 10) return false;
 
-    out.assetPath = assetPath;
     scaleToFit(imgW, imgH, maxW, maxH, out.displayW, out.displayH);
-    return out.displayW > 0 && out.displayH > 0;
-}
+    if (out.displayW <= 0 || out.displayH <= 0) return false;
 
-bool inline_image_render(const String& assetPath,
-                         int dstX, int dstY, int dstW, int dstH) {
-    debug_trace_mark("inline_image_render:start", assetPath);
-    if (!isSupportedImage(assetPath) || dstW <= 0 || dstH <= 0) return false;
-    if ((int)ESP.getFreeHeap() < 20000) return false;
-
-    size_t assetSize = 0;
-    if (!file_has_content(assetPath, &assetSize)) return false;
-
-    ImgDrawCtx ctx;
-    ctx.dstX = dstX;
-    ctx.dstY = dstY;
-    ctx.dstW = dstW;
-    ctx.dstH = dstH;
-    ctx.deadlineMs = millis() + 1500;
-    ctx.lastYieldMs = millis();
-    bool ok = false;
-
-    if (isJpeg(assetPath)) {
-        debug_trace_mark("inline_image_render:jpeg", assetPath);
-        JPEGDEC jpeg;
-        if (jpeg.open(assetPath.c_str(), jpegFileOpen, jpegFileClose, jpegFileRead, jpegFileSeek, ijpegDraw)) {
-            ctx.srcW = jpeg.getWidth();
-            ctx.srcH = jpeg.getHeight();
-            if (inline_image_asset_ok(assetSize, ctx.srcW, ctx.srcH, false)) {
-                g_ictx = &ctx;
-                ok = jpeg.decode(0, 0, 0) == 1;
-                g_ictx = nullptr;
-                if (ctx.aborted) debug_trace_mark("inline_image_render:jpeg_timeout", assetPath);
-            }
-            jpeg.close();
-        }
-    } else if (isPng(assetPath)) {
-        debug_trace_mark("inline_image_render:png", assetPath);
-        PNG png;
-        if (png.open(assetPath.c_str(), pngFileOpen, pngFileClose, pngFileRead, pngFileSeek, ipngDraw) == PNG_SUCCESS) {
-            ctx.srcW = png.getWidth();
-            ctx.srcH = png.getHeight();
-            if (inline_image_asset_ok(assetSize, ctx.srcW, ctx.srcH, true)) {
-                ctx.pngLineBuf = (uint16_t*)ps_malloc((size_t)ctx.srcW * sizeof(uint16_t));
-                if (ctx.pngLineBuf) {
-                    g_ictx = &ctx;
-                    g_ipng_active = &png;
-                    ok = png.decode(nullptr, 0) == PNG_SUCCESS;
-                    g_ipng_active = nullptr;
-                    g_ictx = nullptr;
-                    if (ctx.aborted) debug_trace_mark("inline_image_render:png_timeout", assetPath);
-                    free(ctx.pngLineBuf);
-                    ctx.pngLineBuf = nullptr;
-                } else {
-                    debug_trace_mark("inline_image_render:png_linebuf_alloc_failed", String(ctx.srcW));
-                }
-            }
-            png.close();
+    String rawPath = raw4_cache_path_for(assetPath, out.displayW, out.displayH);
+    if (!raw4_has_valid_size(rawPath, out.displayW, out.displayH)) {
+        debug_trace_mark("inline_image_probe:raw4_build", rawPath);
+        if (!write_raw4_cache_from_image(assetPath, rawPath, imgW, imgH,
+                                         out.displayW, out.displayH, assetSize)) {
+            debug_trace_mark("inline_image_probe:raw4_failed", assetPath);
+            return false;
         }
     }
 
+    out.assetPath = rawPath;
+    return true;
+}
+
+bool inline_image_render(const String& raw4Path,
+                         int dstX, int dstY, int dstW, int dstH) {
+    debug_trace_mark("inline_image_render:raw4", raw4Path);
+    if (dstW <= 0 || dstH <= 0) return false;
+    if (!raw4_has_valid_size(raw4Path, dstW, dstH)) return false;
+
+    File f = SD.open(raw4Path, FILE_READ);
+    if (!f || f.isDirectory()) {
+        if (f) f.close();
+        return false;
+    }
+
+    const int chunk = 64;
+    uint8_t buf[chunk];
+    int x = 0;
+    int y = 0;
+    uint32_t lastYieldMs = millis();
+    bool ok = true;
+
+    while (y < dstH) {
+        int remaining = dstW * dstH - (y * dstW + x);
+        int want = remaining > chunk ? chunk : remaining;
+        int n = f.read(buf, want);
+        if (n != want) { ok = false; break; }
+        for (int i = 0; i < n; i++) {
+            int px = dstX + x;
+            int py = dstY + y;
+            if (px >= 0 && py >= 0 && px < display_width() && py < display_height()) {
+                display_draw_pixel(px, py, buf[i] & 0x0F);
+            }
+            x++;
+            if (x >= dstW) {
+                x = 0;
+                y++;
+                if (y >= dstH) break;
+            }
+        }
+        uint32_t now = millis();
+        if (now - lastYieldMs >= 16) {
+            yield();
+            lastYieldMs = now;
+        }
+    }
+
+    f.close();
     debug_trace_mark("inline_image_render:done", ok ? "ok" : "fail");
     return ok;
 }

--- a/src/inline_image.cpp
+++ b/src/inline_image.cpp
@@ -14,8 +14,7 @@ struct Raw4Ctx {
     int srcW = 0, srcH = 0;
     int dstW = 0, dstH = 0;
     File* out = nullptr;
-    uint8_t* row = nullptr;
-    uint8_t* hits = nullptr;
+    uint8_t* pixels = nullptr;
     uint16_t* pngLineBuf = nullptr;
     uint32_t deadlineMs = 0;
     uint32_t lastYieldMs = 0;
@@ -41,13 +40,11 @@ static bool inline_image_maybe_abort_decode() {
 
 static void raw4_accumulate(int sx, int sy, uint8_t gray4) {
     Raw4Ctx* ctx = g_raw4_ctx;
-    if (!ctx || !ctx->row || !ctx->hits || ctx->srcW <= 0 || ctx->srcH <= 0) return;
+    if (!ctx || !ctx->pixels || ctx->srcW <= 0 || ctx->srcH <= 0) return;
     int dx = (sx * ctx->dstW) / ctx->srcW;
     int dy = (sy * ctx->dstH) / ctx->srcH;
     if (dx < 0 || dy < 0 || dx >= ctx->dstW || dy < 0 || dy >= ctx->dstH) return;
-    size_t idx = (size_t)dy * ctx->dstW + dx;
-    ctx->row[idx] = gray4 & 0x0F;
-    ctx->hits[idx] = 1;
+    ctx->pixels[(size_t)dy * ctx->dstW + dx] = gray4 & 0x0F;
 }
 
 static int raw4JpegDraw(JPEGDRAW* pDraw) {
@@ -291,32 +288,16 @@ static bool extract_asset_to_cache(EpubParser& parser, const String& bookPath,
     outPath = inline_cache_path_for(bookPath, zipPath);
     if (file_has_content(outPath, outSize)) return true;
 
-    size_t dataSize = 0;
-    uint8_t* data = parser.readAsset(zipPath, &dataSize);
-    if (!data || dataSize == 0) {
-        if (data) free(data);
-        return false;
-    }
-    if (dataSize > 8 * 1024 * 1024) {
-        free(data);
-        return false;
-    }
-
     String tmpPath = outPath + ".tmp";
     String tmpVfs = vfs_path(tmpPath);
     String finalVfs = vfs_path(outPath);
 
-    FILE* f = fopen(tmpVfs.c_str(), "wb");
-    if (!f) {
-        free(data);
+    size_t dataSize = 0;
+    if (!parser.extractAssetToFile(zipPath, tmpVfs, &dataSize) || dataSize == 0) {
+        remove(tmpVfs.c_str());
         return false;
     }
-
-    bool ok = fwrite(data, 1, dataSize, f) == dataSize;
-    fclose(f);
-    free(data);
-
-    if (!ok) {
+    if (dataSize > 8 * 1024 * 1024) {
         remove(tmpVfs.c_str());
         return false;
     }
@@ -397,16 +378,13 @@ static bool write_raw4_cache_from_image(const String& assetPath, const String& r
     ctx.lastYieldMs = millis();
 
     size_t pixelCount = (size_t)dstW * (size_t)dstH;
-    ctx.row = (uint8_t*)ps_malloc(pixelCount);
-    ctx.hits = (uint8_t*)ps_calloc(pixelCount, 1);
-    if (!ctx.row || !ctx.hits) {
-        if (ctx.row) free(ctx.row);
-        if (ctx.hits) free(ctx.hits);
+    ctx.pixels = (uint8_t*)ps_malloc(pixelCount);
+    if (!ctx.pixels) {
         out.close();
         SD.remove(tmpPath);
         return false;
     }
-    memset(ctx.row, 15, pixelCount);
+    memset(ctx.pixels, 15, pixelCount);
 
     bool ok = false;
     if (isJpeg(assetPath)) {
@@ -439,12 +417,11 @@ static bool write_raw4_cache_from_image(const String& assetPath, const String& r
     }
 
     if (ok) {
-        size_t written = out.write(ctx.row, pixelCount);
+        size_t written = out.write(ctx.pixels, pixelCount);
         ok = (written == pixelCount);
     }
 
-    free(ctx.row);
-    free(ctx.hits);
+    free(ctx.pixels);
     out.close();
 
     if (!ok) {

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -265,21 +265,77 @@ String BookReader::readLineFromCache(int lineIndex) {
 
 void BookReader::paginateLines() {
     _pages.clear();
-    // Simple fixed-size pagination — no SD reads needed.
-    // Image-aware page breaking would require reading every line from SD
-    // which is too slow (503 file operations). Images that span a page
-    // boundary will just be clipped, which is acceptable.
-    int i = 0;
-    while (i < _totalLines) {
+    if (_totalLines <= 0) {
+        _totalPages = 1;
+        return;
+    }
+
+    File f = SD.open(_lineCachePath, FILE_READ);
+    if (!f) {
+        Serial.printf("paginateLines: cannot open %s, falling back to fixed pagination\n",
+                      _lineCachePath.c_str());
+        int i = 0;
+        while (i < _totalLines) {
+            PageRange pr;
+            pr.lineStart = i;
+            pr.lineEnd = min(i + _linesPerPage, _totalLines);
+            _pages.push_back(pr);
+            i = pr.lineEnd;
+        }
+        _totalPages = _pages.size();
+        if (_totalPages == 0) _totalPages = 1;
+        return;
+    }
+
+    int pageStart = 0;
+    int usedLines = 0;
+    int lineIndex = 0;
+    unsigned long lastYieldMs = millis();
+
+    while (lineIndex < _totalLines) {
+        if (millis() - lastYieldMs >= 25) { yield(); lastYieldMs = millis(); }
+
+        String line;
+        if (lineIndex < (int)_lineOffsets.size()) {
+            f.seek(_lineOffsets[lineIndex]);
+            line = f.readStringUntil('\n');
+        }
+
+        int consumes = 1;
+        String imgPath;
+        int imgW = 0, imgH = 0, imgLines = 0;
+        bool isImage = inline_image_parse_enriched(line, imgPath, imgW, imgH, imgLines);
+        if (isImage) {
+            consumes = max(1, imgLines);
+        } else if (inline_image_is_continuation(line)) {
+            consumes = 1;
+        }
+
+        if (usedLines > 0 && usedLines + consumes > _linesPerPage) {
+            PageRange pr;
+            pr.lineStart = pageStart;
+            pr.lineEnd = lineIndex;
+            _pages.push_back(pr);
+            pageStart = lineIndex;
+            usedLines = 0;
+            continue;
+        }
+
+        usedLines += consumes;
+        lineIndex += isImage ? consumes : 1;
+    }
+
+    f.close();
+
+    if (pageStart < _totalLines) {
         PageRange pr;
-        pr.lineStart = i;
-        pr.lineEnd = min(i + _linesPerPage, _totalLines);
+        pr.lineStart = pageStart;
+        pr.lineEnd = _totalLines;
         _pages.push_back(pr);
-        i = pr.lineEnd;
     }
     _totalPages = _pages.size();
     if (_totalPages == 0) _totalPages = 1;
-    Serial.printf("Paginated: %d pages from %d lines (%d lines/page)\n",
+    Serial.printf("Paginated: %d pages from %d lines (%d lines/page, image-aware)\n",
                   _totalPages, _totalLines, _linesPerPage);
 }
 

--- a/src/ui/ui_reader.cpp
+++ b/src/ui/ui_reader.cpp
@@ -141,16 +141,20 @@ void ui_reader_draw(BookReader& reader, ReaderRefreshState& refresh) {
             if (inline_image_is_marker(line)) {
                 String imgPath; int imgW, imgH, imgLines;
                 if (inline_image_parse_enriched(line, imgPath, imgW, imgH, imgLines)) {
-                    debug_trace_mark("ui_reader_draw:inline_image_hotfix_placeholder", imgPath);
-                    int safeW = max(24, min(imgW, W - marginX * 2));
+                    int safeW = max(1, min(imgW, W - marginX * 2));
+                    int safeH = max(1, min(imgH, bodyBottom - (y - fontAscender)));
                     int imgX = marginX + (W - marginX * 2 - safeW) / 2;
                     int imgY = y - fontAscender;
-                    display_draw_rect(imgX, imgY, safeW, lineH, 10);
-                    display_draw_text(marginX, y, "[image hidden for stability]", 8);
+                    debug_trace_mark("ui_reader_draw:inline_image_render", imgPath);
+                    if (!inline_image_render(imgPath, imgX, imgY, imgW, imgH)) {
+                        debug_trace_mark("ui_reader_draw:inline_image_render_failed", imgPath);
+                        display_draw_rect(imgX, imgY, safeW, min(safeH, lineH), 10);
+                        display_draw_text(marginX, y, "[image unavailable]", 8);
+                    }
                 }
-                y += lineH;
+                y += max(lineH, imgLines * lineH);
             } else if (inline_image_is_continuation(line)) {
-                // Image continuation placeholder — just advance Y
+                // Image continuation marker — space was consumed by the image
                 y += lineH;
             } else {
                 display_draw_text(marginX, y, line.c_str(), 0);


### PR DESCRIPTION
## Summary
- Pre-render EPUB inline images into SD-backed `.r4` raw 4-bit grayscale cache files during chapter wrapping/probing
- Change reader draw path to stream cached raw pixels from SD instead of decoding PNG/JPEG during page draw
- Allocate PNG/JPEG decoder objects on heap during cache creation/probing to avoid large decoder objects on the Arduino loop stack
- Fix PNG file callbacks to update `iPos` and use seek semantics matching the decoder callbacks

## Test
- `cp include/config.h.example include/config.h`
- `pio run -e lilygo-t5-47-s3`

## Notes
- Intended for hardware testing after the v0.4.3 hotfix. The first view of a chapter with images may do decode/cache work; later draws stream the `.r4` file directly from SD.
